### PR TITLE
Fixed issue after scaffolding MVC Controller

### DIFF
--- a/RoverCore.Boilerplate.Web/Templates/ControllerGenerator/MvcControllerWithContext.cshtml
+++ b/RoverCore.Boilerplate.Web/Templates/ControllerGenerator/MvcControllerWithContext.cshtml
@@ -348,7 +348,7 @@ foreach (var property in Model.ModelMetadata.Properties)
 	{
 			@:var query = _context.@(entitySetName);
 	}
-			@:var jsonData = await query.GetDatatableResponseAsync<@(entitySetName), @(entitySetName)IndexViewModel>(request);
+			@:var jsonData = await query.GetDatatableResponseAsync@(Model.ModelTypeName), @(entitySetName)IndexViewModel>(request);
 }
 
             return Ok(jsonData);


### PR DESCRIPTION
Model was being pluralized causing an error. Changed to be singular by using `@(Model.ModelTypeName)`